### PR TITLE
#162179070 Add endpoint to create new git cheat

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "joi": "^14.1.0",
     "jsonwebtoken": "^8.4.0",
     "mongoose": "^5.3.13",
+    "mongoose-unique-validator": "^2.0.2",
     "morgan": "^1.9.1",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
@@ -25,7 +26,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "start:dev": "nodemon --exec babel-node ./server",
-    "test:server": "NODE_ENV=test nyc mocha --require @babel/register server/__tests__/**/*.js --exit"
+    "test:server": "NODE_ENV=test nyc mocha --require @babel/register server/__tests__/*.js --exit"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/server/__tests__/__mocks__/index.js
+++ b/server/__tests__/__mocks__/index.js
@@ -1,0 +1,59 @@
+const users = [{
+  username: 'anonymous',
+  password: 'password234',
+  role: 'admin',
+}, {
+  username: 'anonymous1',
+  password: 'password234',
+}, {
+  username: 'anonymous2',
+  password: 'password234',
+}];
+
+const unknownUserToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI1YmY5Y2I2ZjM2OGE0N2RiOGQzZDE4OTIiLCJpYXQiOjE1NDMwOTcxOTksImV4cCI6MTU0MzE4MzU5OX0.yvvGq-EWjZ-a71HSgpHO0_TNwnq6Igfa81ztaO_bxAM';
+
+const cheats = [{
+  category: "Make changes",
+	description: "Check the changes made",
+	command: "git status"
+}, {
+  category: "Make changes",
+	description: "Move a file with changes made to staging area",
+	command: "git add [file]"
+}, {
+	description: "Move a file with changes made to staging area",
+	command: "git add [file]"
+}, {
+  category: "Make changes",
+	command: "git add [file]"
+}, {
+  category: "Make changes",
+	description: "Move a file with changes made to staging area",
+}];
+
+const createUser = (Model, jwt, isAdmin = false, index = 1) => {
+  const userData = isAdmin ? users[0] : users[index]
+  const user = new Model(userData);
+
+  return new Promise((resolve, reject) => {
+    user.save((err, newUser) => {
+      const token = jwt.sign({
+        userId: newUser._id
+      }, process.env.JWT_SECRET, {
+        expiresIn: 60 * 60 * 24,
+      })
+
+      resolve({ newUser, token})
+    });
+  });
+};
+
+const createCheat = (Model, index = 0) => {
+  const cheat = new Model(cheats[index]);
+
+  return new Promise((resolve, reject) => {
+    cheat.save((err, newCheat) => resolve(newCheat));
+  });
+};
+
+export { users, unknownUserToken, cheats, createUser, createCheat };

--- a/server/__tests__/gitCheat.js
+++ b/server/__tests__/gitCheat.js
@@ -1,0 +1,170 @@
+import supertest from 'supertest';
+import chai from 'chai';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+
+import app from '../';
+import GitCheat from '../models/gitCheat';
+import User from '../models/user';
+import { unknownUserToken, cheats, createUser } from './__mocks__';
+
+const server = supertest.agent(app);
+const expect = chai.expect;
+
+describe('Git cheat endpoint', () => {
+  before(done => {
+    mongoose.connect(process.env.DB_TEST_URL, {
+      useNewUrlParser: true,
+      useCreateIndex: true,
+    });
+
+    const dbConnection = mongoose.connection;
+
+    dbConnection.once('open', () => {
+      console.log('Connected to test database!');
+      done();
+    });
+    dbConnection.on('error', console.error.bind(console, 'connection error'));
+  });
+  after(done => {
+    mongoose.connection.db.dropDatabase(() => {
+      mongoose.connection.close(done);
+      console.log('Database connection closed');
+    });
+  });
+
+  describe('Add cheat', () => {
+    let adminUser;
+    let newUser;
+    before(async () => {
+      adminUser = await createUser(User, jwt, true);
+      newUser = await createUser(User, jwt, false, 1);
+    });
+
+    after((done) => {
+      GitCheat.deleteMany({}, (err) => {
+        User.deleteMany({}, (err) => {
+          done();
+        });
+      });
+    });
+    it('should return error if no token is provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send(cheats[0])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(401);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('No token provided')
+          done();
+        });
+    });
+
+    it('should return error if an invalid token is provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', 'invalid-token')
+        .send(cheats[0])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(401);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('Invalid token')
+          done();
+        });
+    });
+
+    it('should return error if a valid token from unknown user is provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', unknownUserToken)
+        .send(cheats[0])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(404);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('User not found')
+          done();
+        });
+    });
+
+    it('should not allow a non admin user add a cheat', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', newUser.token)
+        .send(cheats[0])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(403);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('Unauthorized access')
+          done();
+        });
+    });
+
+    it('should allow an admin user add a cheat', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', adminUser.token)
+        .send(cheats[0])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(201);
+          expect(res.body.status).to.equal('success');
+          expect(res.body.message).to.equal('Git cheat created')
+          done();
+        });
+    });
+
+    it('should return error if category is not provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', adminUser.token)
+        .send(cheats[2])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(400);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('Input `category` is required')
+          done();
+        });
+    });
+
+    it('should return error if description is not provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', adminUser.token)
+        .send(cheats[3])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(400);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('Input `description` is required')
+          done();
+        });
+    });
+
+    it('should return error if command is not provided', (done) => {
+      server.post('/api/v1/cheats')
+        .set('Connection', 'keep alive')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .set('x-access-token', adminUser.token)
+        .send(cheats[4])
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(400);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.message).to.equal('Input `command` is required')
+          done();
+        });
+    });
+  });
+});

--- a/server/__tests__/user.js
+++ b/server/__tests__/user.js
@@ -81,7 +81,7 @@ describe('User authentication endpoint', () => {
         .end((err, res) => {
           expect(res.statusCode).to.equal(409);
           expect(res.body.status).to.equal('error');
-          expect(res.body.message).to.equal('Username already exist');
+          expect(res.body.message).to.equal('username already exist');
           done();
         });
     });

--- a/server/__tests__/user.js
+++ b/server/__tests__/user.js
@@ -57,7 +57,7 @@ describe('User authentication endpoint', () => {
         });
     });
 
-    it('should return register a user successfully', (done) => {
+    it('should register a user with valid inputs successfully', (done) => {
       server.post('/api/v1/auth/signup')
         .set('Connection', 'keep alive')
         .set('Content-Type', 'application/json')

--- a/server/__tests__/user.js
+++ b/server/__tests__/user.js
@@ -126,6 +126,7 @@ describe('User authentication endpoint', () => {
           expect(res.statusCode).to.equal(200);
           expect(res.body.status).to.equal('success');
           expect(res.body.message).to.equal('User logged in');
+          expect(res.body.data.username).to.equal('acceptable')
           expect(res.body.data.token).to.be.a('string');
           done();
         });

--- a/server/controllers/gitCheat.js
+++ b/server/controllers/gitCheat.js
@@ -6,6 +6,33 @@ class GitCheatController {
 
     newGitCheat.save((error, gitCheat) => {
       if (error) {
+        if (error.message.includes('GitCheat validation failed: category')) {
+          return res.status(400).json({
+            status: 'error',
+            message: error.message.substring(
+              error.message.indexOf('category:') + 10,
+              error.message.indexOf('.')).replace('Path', 'Input'),
+          });
+        }
+
+        if (error.message.includes('GitCheat validation failed: description')) {
+          return res.status(400).json({
+            status: 'error',
+            message: error.message.substring(
+              error.message.indexOf('description:') + 13,
+              error.message.indexOf('.')).replace('Path', 'Input'),
+          });
+        }
+
+        if (error.message.includes('GitCheat validation failed: command')) {
+          return res.status(400).json({
+            status: 'error',
+            message: error.message.substring(
+              error.message.indexOf('command:') + 9,
+              error.message.indexOf('.')).replace('Path', 'Input'),
+          });
+        }
+
         return res.status(500).json({
           status: 'error',
           message: error.message,

--- a/server/controllers/gitCheat.js
+++ b/server/controllers/gitCheat.js
@@ -1,0 +1,24 @@
+import GitCheat from '../models/gitCheat';
+
+class GitCheatController {
+  static createGitCheat(req, res) {
+    const newGitCheat = new GitCheat(req.body);
+
+    newGitCheat.save((error, gitCheat) => {
+      if (error) {
+        return res.status(500).json({
+          status: 'error',
+          message: error.message,
+        });
+      }
+
+      return res.status(201).json({
+        status: 'success',
+        message: 'Git cheat created',
+        data: gitCheat,
+      });
+    });
+  }
+};
+
+export default GitCheatController;

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -23,7 +23,9 @@ class UserController {
     newUser.save((error, user) => {
       if (error) {
         if (error.message.includes('User validation failed: username')) {
-          return res.status(400).json({
+          const statusCode = error.message.includes('exist') ? 409 : 400;
+
+          return res.status(statusCode).json({
             status: 'error',
             message: error.message.substring(
               error.message.indexOf('username:') + 10,
@@ -38,13 +40,6 @@ class UserController {
               error.message.indexOf('password:') + 10,
               error.message.indexOf('.')).replace('Path', 'Input'),
           });
-        }
-
-        if (error.message.includes('duplicate')) {
-          return res.status(409).json({
-            status: 'error',
-            message: 'Username already exist'
-          })
         }
 
         return res.status(500).json({

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -18,7 +18,10 @@ class UserController {
    * @memberof UserController
    */
   static createUser(req, res) {
-    const newUser = new User(req.body);
+    const newUser = new User({
+      username: req.body.username,
+      password: req.body.password,
+    });
 
     newUser.save((error, user) => {
       if (error) {
@@ -58,6 +61,7 @@ class UserController {
         status: 'success',
         message: 'User created',
         data: {
+          username: user.username,
           token
         }
       });
@@ -99,6 +103,7 @@ class UserController {
             status: 'success',
             message: 'User logged in',
             data: {
+              username: user.username,
               token
             }
           });

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,7 @@ if (process.env.NODE_ENV !== 'test') {
     'error', console.error.bind(console, 'MongoDB connection error:'));
 }
 
-app.use(logger('short'));
+app.use(logger('dev'));
 app.use(bodyParser.json());
 
 routes(app);

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,31 @@
+import jwt from 'jsonwebtoken';
+
+const verifyToken = (req, res, next) => {
+  const token = req.headers['x-access-token'];
+
+  if (!token) {
+    return res.status(401).json({
+      status: 'error',
+      message: 'No token provided'
+    });
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (err) {
+      if (err.message.includes('token')) {
+        return res.status(401).json({
+          status: 'error',
+          message: 'Invalid token'
+        });
+      }
+      return res.status(401).json({
+        status: 'error',
+        message: err.message,
+      });
+    }
+    req.decoded = decoded;
+    return next();
+  });
+};
+
+export default verifyToken;

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -12,7 +12,8 @@ const verifyToken = (req, res, next) => {
 
   jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
     if (err) {
-      if (err.message.includes('token')) {
+      if (err.message.includes('invalid')
+          || err.message.includes('malformed')) {
         return res.status(401).json({
           status: 'error',
           message: 'Invalid token'

--- a/server/middleware/authAdmin.js
+++ b/server/middleware/authAdmin.js
@@ -1,0 +1,28 @@
+import User from '../models/user';
+
+const authenticateAdmin = (req, res, next) => {
+  User.findById(req.decoded.userId, (error, user) => {
+    if (error) {
+      return res.status(500).json({
+        status: 'error',
+        message: error.message,
+      });
+    }
+
+    if (user) {
+      if (user.role === 'admin') return next()
+
+      return res.status(403).json({
+        status: 'error',
+        message: 'Unauthorized access'
+      });
+    }
+
+    return res.status(404).json({
+      status: 'error',
+      message: 'User not found'
+    });
+  });
+};
+
+export default authenticateAdmin;

--- a/server/models/gitCheat.js
+++ b/server/models/gitCheat.js
@@ -5,15 +5,19 @@ const GitCheatSchema = new Schema({
   category: {
     type: String,
     required: true,
+    trim: true,
   },
   description: {
     type: String,
     required: true,
+    trim: true,
   },
   command: {
     type: String,
     required: true,
-  }
+    trim: true,
+  },
+  keywords: [String],
 });
 
 const GitCheat = mongoose.model('GitCheat', GitCheatSchema);

--- a/server/models/gitCheat.js
+++ b/server/models/gitCheat.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import uniqueValidator from 'mongoose-unique-validator';
 
 const Schema = mongoose.Schema;
 const GitCheatSchema = new Schema({
@@ -14,11 +15,16 @@ const GitCheatSchema = new Schema({
   },
   command: {
     type: String,
+    unique: true,
     required: true,
     trim: true,
   },
   keywords: [String],
 });
+
+GitCheatSchema.plugin(uniqueValidator, {
+  message: '{PATH} already exist.'
+})
 
 const GitCheat = mongoose.model('GitCheat', GitCheatSchema);
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -22,6 +22,11 @@ const UserSchema = new Schema({
     type: String,
     minlength: [8, 'Password must contain at least 8 characters.'],
     required: true,
+  },
+  role: {
+    type: String,
+    enum: ['admin', 'user'],
+    default: 'user',
   }
 });
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import bcrypt from 'bcrypt';
+import uniqueValidator from 'mongoose-unique-validator';
 
 const SALT_WORK_FACTOR = 10;
 
@@ -49,6 +50,10 @@ UserSchema.pre('save', async function(next) {
 UserSchema.methods.validatePassword = async function(password) {
   return bcrypt.compare(password, this.password);
 }
+
+UserSchema.plugin(uniqueValidator, {
+  message: '{PATH} already exist.'
+});
 
 const User = mongoose.model('User', UserSchema);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,13 @@
 import UserController from '../controllers/user';
+import GitCheatController from '../controllers/gitCheat';
+import verifyToken from '../middleware/auth';
+import authenticateAdmin from '../middleware/authAdmin';
 
 export default (app) => {
   app.post('/api/v1/auth/signup', UserController.createUser);
 
   app.post('/api/v1/auth/login', UserController.loginUser);
+
+  app.route('/api/v1/cheats')
+    .post(verifyToken, authenticateAdmin, GitCheatController.createGitCheat);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5509,7 +5509,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
-lodash.get@4.4.2:
+lodash.foreach@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.get@4.4.2, lodash.get@^4.0.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
@@ -5928,6 +5932,13 @@ mongodb@3.1.10:
 mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
+
+mongoose-unique-validator@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mongoose-unique-validator/-/mongoose-unique-validator-2.0.2.tgz#a980e68638157cd8fcea86d754eeb2cf67e6bb76"
+  dependencies:
+    lodash.foreach "^4.1.0"
+    lodash.get "^4.0.2"
 
 mongoose@^5.3.13:
   version "5.3.13"


### PR DESCRIPTION
#### What does this PR do?
- Add an endpoint to create a new cheat
#### Description of Task to be completed?
- add route and handler to create a new cheat
- add tests for the create cheat functionality
#### How should this be manually tested?
- Fetch the branch with the changes with the command: `git fetch ft-admin-add-cheat-162179070:ft-admin-add-cheat-162179070`
- Checkout to the branch with the command: `git checkout ft-admin-add-cheat-162179070`
- Start the application with the command: `yarn start:dev`
- Using postman, log in as an admin user and create a new cheat via: `POST: localhost:8800/api/v1/cheats`. The payload should contain 
```
  {
    category: a string,
    description: a sting,
    command: a string,
    keywords: an array of strings if any
  }
```
- Run the tests with the command: `yarn test:server`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- #162179070
#### Screenshots (if appropriate)
<img width="1086" alt="screen shot 2018-11-25 at 3 32 59 pm" src="https://user-images.githubusercontent.com/28486643/48980309-942dfc80-f0c7-11e8-84b7-abf7ac92548d.png">

#### Questions:
- N/A