### PR TITLE
#162179082 Add update cheat endpoint

### DIFF
--- a/server/__tests__/__mocks__/index.js
+++ b/server/__tests__/__mocks__/index.js
@@ -30,6 +30,9 @@ const cheats = [{
 }, {
   category: "Make changes",
 	description: "Move a file with changes made to staging area",
+}, {
+  category: "Make changes",
+  keywords: ["Change"]
 }];
 
 const createUser = (Model, jwt, isAdmin = false, index = 1) => {

--- a/server/controllers/gitCheat.js
+++ b/server/controllers/gitCheat.js
@@ -88,6 +88,55 @@ class GitCheatController {
       });
     });
   }
+
+  /**
+   * Update git cheat
+   *
+   * @static
+   * @param {object} req - Request object
+   * @param {object} res - Response object
+   *
+   * @returns {object} Response object
+   * @memberof GitCheatController
+   */
+  static updateGitCheat(req, res) {
+    GitCheat.findById(req.params.cheatId, (error, cheat) => {
+      if (error) {
+        return res.status(500).json({
+          status: 'error',
+          message: error.message,
+        });
+      }
+
+      if (!cheat) {
+        return res.status(404).json({
+          status: 'error',
+          message: 'Cheat not found',
+        });
+      }
+
+      for (let key in req.body) {
+        if (cheat.get(key)) {
+          cheat[key] = req.body[key];
+        }
+      }
+
+      cheat.save((err, updatedCheat) => {
+        if (err) {
+          return res.status(500).json({
+            status: 'error',
+            message: error.message,
+          });
+        }
+
+        return res.status(200).json({
+          status: 'success',
+          message: 'Git cheat updated',
+          data: { cheat: updatedCheat }
+        });
+      });
+    });
+  }
 };
 
 export default GitCheatController;

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -13,7 +13,8 @@ const verifyToken = (req, res, next) => {
   jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
     if (err) {
       if (err.message.includes('invalid')
-          || err.message.includes('malformed')) {
+          || err.message.includes('malformed')
+          || err.message.includes('expired')) {
         return res.status(401).json({
           status: 'error',
           message: 'Invalid token'

--- a/server/middleware/authUser.js
+++ b/server/middleware/authUser.js
@@ -11,9 +11,9 @@ const authenticateUser = (req, res, next) => {
 
     if (user) return next()
 
-    return res.status(404).json({
+    return res.status(401).json({
       status: 'error',
-      message: 'User not found'
+      message: 'Invalid token'
     });
   });
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,4 +12,7 @@ export default (app) => {
   app.route('/api/v1/cheats')
     .post(verifyToken, authenticateAdmin, GitCheatController.createGitCheat)
     .get(verifyToken, authenticateUser, GitCheatController.getAllCheats);
+
+  app.route('/api/v1/cheats/:cheatId')
+    .put(verifyToken, authenticateAdmin, GitCheatController.updateGitCheat);
 };


### PR DESCRIPTION
#### What does this PR do?
- Add an endpoint to update a cheat
#### Description of Task to be completed?
- add edit cheat functionality and secure the route for admin access only
- add tests for edit cheat functionality
#### How should this be manually tested?
- Fetch the branch with the changes with the command: `git fetch ft-update-cheat-endpoint-162179082:ft-update-cheat-endpoint-162179082`
- Checkout to the branch with the command: `git checkout ft-update-cheat-endpoint-162179082`
- Start the application with the command: `yarn start:dev`
- Using postman, log in as an admin user and update a cheat via: `PUT: localhost:8800/api/v1/cheats/<cheatId>`. The payload should contain any or all of these:
```
  {
    category: a string,
    description: a sting,
    command: a string,
    keywords: an array of strings if any
  }
```
- Run the tests with the command: `yarn test:server`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- #162179082
#### Screenshots (if appropriate)
<img width="1094" alt="screen shot 2018-11-26 at 12 38 36 am" src="https://user-images.githubusercontent.com/28486643/49045160-5f599c80-f1d0-11e8-99f0-9459e8942d14.png">

#### Questions:
- N/A